### PR TITLE
suggest proper location for custom systemd service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you want edgebridge to automatically start and run in the background whenever
 
 - Create a systemd service file:
   ```
-  cd /lib/systemd/system
+  cd /etc/systemd/system
   sudo nano edgebridge.service
   ```
   


### PR DESCRIPTION
Custom systemd service files should be put into /etc/systemd/system as opposed to /lib/systemd/system

From: https://www.freedesktop.org/software/systemd/man/systemd.unit.html

> /etc/systemd/system | System units created by the administrator


